### PR TITLE
Revert "Update cairo options (DTO-675)"

### DIFF
--- a/profiles/centos7-gcc10-x86_64
+++ b/profiles/centos7-gcc10-x86_64
@@ -31,15 +31,15 @@ libxl:compiler.cppstd=14
 [options]
 # Cairo configuration
 # Disable glib unless required
-cairo:with_glib=False
+cairo:enable_glib=False
 # Use freetype
-cairo:with_freetype=True
+cairo:enable_ft=True
 # Use fontconfig
-cairo:with_fontconfig=True
+cairo:enable_fc=True
 # Disable dependency on X Window System if possible
-cairo:with_xlib=False
-cairo:with_xlib_xrender=False
-cairo:with_xcb=False
+cairo:enable_xlib=False
+cairo:enable_xlib_xrender=False
+cairo:enable_xcb=False
 
 [build_requires]
 

--- a/profiles/macos-xcode12-x86_64
+++ b/profiles/macos-xcode12-x86_64
@@ -46,11 +46,11 @@ libxl:compiler.cppstd=14
 [options]
 # Cairo configuration
 # Disable glib unless required
-cairo:with_glib=False
+cairo:enable_glib=False
 # Use freetype
-cairo:with_freetype=True
+cairo:enable_ft=True
 # Use fontconfig
-cairo:with_fontconfig=True
+cairo:enable_fc=True
 
 # We prefer using static libraries for these packages on macos
 # Expat is used by the ImageIO.framework. ImageIO is used by openscenegraph

--- a/profiles/macos-xcode13-armv8
+++ b/profiles/macos-xcode13-armv8
@@ -48,11 +48,11 @@ libxl:compiler.cppstd=14
 [options]
 # Cairo configuration
 # Disable glib unless required
-cairo:with_glib=False
+cairo:enable_glib=False
 # Use freetype
-cairo:with_freetype=True
+cairo:enable_ft=True
 # Use fontconfig
-cairo:with_fontconfig=True
+cairo:enable_fc=True
 
 # We prefer using static libraries for these packages on macos
 # Expat is used by the ImageIO.framework. ImageIO is used by openscenegraph

--- a/profiles/macos-xcode13-x86_64
+++ b/profiles/macos-xcode13-x86_64
@@ -47,11 +47,11 @@ libxl:compiler.cppstd=14
 [options]
 # Cairo configuration
 # Disable glib unless required
-cairo:with_glib=False
+cairo:enable_glib=False
 # Use freetype
-cairo:with_freetype=True
+cairo:enable_ft=True
 # Use fontconfig
-cairo:with_fontconfig=True
+cairo:enable_fc=True
 
 # We prefer using static libraries for these packages on macos
 # Expat is used by the ImageIO.framework. ImageIO is used by openscenegraph

--- a/profiles/macos-xcode14-armv8
+++ b/profiles/macos-xcode14-armv8
@@ -48,11 +48,11 @@ libxl:compiler.cppstd=14
 [options]
 # Cairo configuration
 # Disable glib unless required
-cairo:with_glib=False
+cairo:enable_glib=False
 # Use freetype
-cairo:with_freetype=True
+cairo:enable_ft=True
 # Use fontconfig
-cairo:with_fontconfig=True
+cairo:enable_fc=True
 
 # We prefer using static libraries for these packages on macos
 # Expat is used by the ImageIO.framework. ImageIO is used by openscenegraph

--- a/profiles/macos-xcode14-x86_64
+++ b/profiles/macos-xcode14-x86_64
@@ -47,11 +47,11 @@ libxl:compiler.cppstd=14
 [options]
 # Cairo configuration
 # Disable glib unless required
-cairo:with_glib=False
+cairo:enable_glib=False
 # Use freetype
-cairo:with_freetype=True
+cairo:enable_ft=True
 # Use fontconfig
-cairo:with_fontconfig=True
+cairo:enable_fc=True
 
 # We prefer using static libraries for these packages on macos
 # Expat is used by the ImageIO.framework. ImageIO is used by openscenegraph

--- a/profiles/ubuntu20-gcc10-x86_64
+++ b/profiles/ubuntu20-gcc10-x86_64
@@ -31,15 +31,15 @@ libxl:compiler.cppstd=14
 [options]
 # Cairo configuration
 # Disable glib unless required
-cairo:with_glib=False
+cairo:enable_glib=False
 # Use freetype
-cairo:with_freetype=True
+cairo:enable_ft=True
 # Use fontconfig
-cairo:with_fontconfig=True
+cairo:enable_fc=True
 # Disable dependency on X Window System if possible
-cairo:with_xlib=False
-cairo:with_xlib_xrender=False
-cairo:with_xcb=False
+cairo:enable_xlib=False
+cairo:enable_xlib_xrender=False
+cairo:enable_xcb=False
 
 [build_requires]
 

--- a/profiles/windows-msvc16-amd64
+++ b/profiles/windows-msvc16-amd64
@@ -57,7 +57,7 @@ mariadb-connector-c:compiler.version=16
 
 [options]
 # Disable glib unless required
-cairo:with_glib=False
+cairo:enable_glib=False
 
 # See the more extensive comment in common-default-options
 gtest:shared=False


### PR DESCRIPTION
This reverts commit 9b3ca0f7927f108ccdc498fc20391b6571c06732. This commit updated the cairos configuration to a new version which we were planning to use.

We are still using an older build of cairos at the moment.