### PR TITLE
zlib:minizip option added (BLD-6874)

### DIFF
--- a/profiles/common-default-options
+++ b/profiles/common-default-options
@@ -99,5 +99,8 @@ libarchive:with_zlib=True
 libarchive:with_bzip2=True
 libarchive:with_zstd=True
 
+# Not sure about this ...
+zlib:minizip=deprecated
+
 [build_requires]
 [env]


### PR DESCRIPTION
This option was seen in build where conan couldn't find a libxslt package.