### PR TITLE
Remove conan 2 repos from remotes.txt (PLA-2304)

### DIFF
--- a/remotes.txt
+++ b/remotes.txt
@@ -3,5 +3,3 @@ ccdc-3rdparty-conan-testing https://artifactory.ccdc.cam.ac.uk/artifactory/api/c
 public-conan-center https://artifactory.ccdc.cam.ac.uk/artifactory/api/conan/public-conan-center True
 public-conan-bincrafters https://artifactory.ccdc.cam.ac.uk/artifactory/api/conan/public-conan-bincrafters True
 public-conan-center-1 https://center.conan.io True
-public-conan-center-2 https://center2.conan.io True
-ccdc-3rdparty-conan-2 https://proget.ccdc.cam.ac.uk/conan/ccdc-3rdparty-conan True


### PR DESCRIPTION
remotes.txt is only used by conan 1. conan 2 uses remotes.json.