### PR TITLE
PLA-2304 Fix specification of cppstd

### DIFF
--- a/profiles/windows-msvc16-amd64
+++ b/profiles/windows-msvc16-amd64
@@ -18,7 +18,7 @@ compiler.cppstd=17
 # We have to build csdprotobufs with vs2022 as the github runner with vs2019
 # is no longer available from July 2025.
 csdprotobufs:compiler.version=17
-csdprotobufs:cppstd=20
+csdprotobufs:compiler.cppstd=20
 
 # libtool 
 libtool:compiler=Visual Studio


### PR DESCRIPTION
Change to fix the following error from configuring

ERROR: Error in resulting settings for package 'csdprotobufs': Do not use settings 'compiler.cppstd' together with 'cppstd'. Use only the former one.
arch=x86_64
arch_build=x86_64
build_type=Debug
compiler=Visual Studio
compiler.cppstd=17
compiler.runtime=MDd
compiler.toolset=v142
compiler.version=17
os=Windows
os_build=Windows
cppstd=20
conan install error