### PR TITLE
PLA-2304_clear_toolset

### DIFF
--- a/profiles/windows-msvc16-amd64
+++ b/profiles/windows-msvc16-amd64
@@ -20,7 +20,7 @@ compiler.cppstd=17
 # to the rest of this build, so override the package metadata that conan is searching for
 csdprotobufs:compiler.version=17
 csdprotobufs:compiler.cppstd=20
-csdprotobufs:compiler.toolset=
+csdprotobufs:compiler.toolset=None
 
 # libtool 
 libtool:compiler=Visual Studio

--- a/profiles/windows-msvc16-amd64
+++ b/profiles/windows-msvc16-amd64
@@ -20,7 +20,7 @@ compiler.cppstd=17
 # to the rest of this build, so override the package metadata that conan is searching for
 csdprotobufs:compiler.version=17
 csdprotobufs:compiler.cppstd=20
-csdprotobufs:compiler.toolset!
+csdprotobufs:compiler.toolset=
 
 # libtool 
 libtool:compiler=Visual Studio

--- a/profiles/windows-msvc16-amd64
+++ b/profiles/windows-msvc16-amd64
@@ -20,7 +20,7 @@ compiler.cppstd=17
 # to the rest of this build, so override the package metadata that conan is searching for
 csdprotobufs:compiler.version=17
 csdprotobufs:compiler.cppstd=20
-csdprotobufs:compiler.toolset=
+csdprotobufs:compiler.toolset!
 
 # libtool 
 libtool:compiler=Visual Studio

--- a/profiles/windows-msvc16-amd64
+++ b/profiles/windows-msvc16-amd64
@@ -16,9 +16,11 @@ compiler.cppstd=17
 
 # csdprotobufs
 # We have to build csdprotobufs with vs2022 as the github runner with vs2019
-# is no longer available from July 2025.
+# is no longer available from July 2025. This is a slightly different configuration
+# to the rest of this build, so override the package metadata that conan is searching for
 csdprotobufs:compiler.version=17
 csdprotobufs:compiler.cppstd=20
+csdprotobufs:compiler.toolset=
 
 # libtool 
 libtool:compiler=Visual Studio


### PR DESCRIPTION
This PR clears the toolset, which is only required for VS2019, so the VS2022 built libraries can be found by conan.
