### PR TITLE
Move windows debug settings from ccdc-main to common (DO-1376)

### DIFF
--- a/profiles/windows-msvc17-amd64-debug-2
+++ b/profiles/windows-msvc17-amd64-debug-2
@@ -17,5 +17,46 @@ winflexbison:compiler.runtime_type=Release
 swig:compiler.runtime=dynamic
 swig:compiler.runtime_type=Release
 
+
+# Library dependencies
+# by changing the compiler.runtime and build_type of groups of these libraries in a
+# way that clusters of them work consistently, you can use debug versions of these
+# third party libraries
+libxl:compiler.runtime=dynamic
+libxl:compiler.runtime_type=Release
+libxl:build_type=Release
+
+freetype:compiler.runtime=dynamic
+freetype:compiler.runtime_type=Release
+freetype:build_type=Release
+
+bzip2:compiler.runtime=dynamic
+bzip2:compiler.runtime_type=Release
+bzip2:build_type=Release
+
+libiconv:compiler.runtime=dynamic
+libiconv:compiler.runtime_type=Release
+libiconv:build_type=Release
+
+zstd:compiler.runtime=dynamic
+zstd:compiler.runtime_type=Release
+zstd:build_type=Release
+
+libarchive:compiler.runtime=dynamic
+libarchive:compiler.runtime_type=Release
+libarchive:build_type=Release
+
+inchi:compiler.runtime=dynamic
+inchi:compiler.runtime_type=Release
+inchi:build_type=Release
+
+ccdcsqlite3:compiler.runtime=dynamic
+ccdcsqlite3:compiler.runtime_type=Release
+ccdcsqlite3:build_type=Release
+
+zlib:compiler.runtime=dynamic
+zlib:compiler.runtime_type=Release
+zlib:build_type=Release
+
 [options]
 


### PR DESCRIPTION
This is the set of settings we use for Windows debug builds. It's better to centralize the settings, since the settings are all sensible settings and the profile is used exclusively by our main builds. We want as little customization in the ccdc-main as possible.